### PR TITLE
feat: persist anvil state between restarts

### DIFF
--- a/charts/scroll-stack/charts/l1-devnet/values.yaml
+++ b/charts/scroll-stack/charts/l1-devnet/values.yaml
@@ -5,8 +5,8 @@ global:
 
 controller:
   replicas: 1
-  strategy: Recreate
-  type: deployment
+  strategy: RollingUpdate
+  type: statefulset
 
 image:
   repository: ghcr.io/foundry-rs/foundry
@@ -14,7 +14,7 @@ image:
   tag: nightly-19d69f277de96f621d930cdb767a9693c55ae8e1
 
 command:
-  ["/bin/sh","-c","source /chain-id/chain-id.txt && anvil --host 0.0.0.0 --port 8545 --chain-id ${CHAIN_ID} --state state.json --state-interval 60"]
+  ["/bin/sh","-c","source /chain-id/chain-id.txt && anvil --host 0.0.0.0 --port 8545 --chain-id ${CHAIN_ID} --state /data/state.json --state-interval 60"]
 
 resources:
   requests:
@@ -53,6 +53,12 @@ persistence:
     accessMode: ReadWriteOnce
     size: 10Mi
     mounthPath: /chain-id
+  data:
+    enabled: yes
+    type: pvc
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    mounthPath: /data
 
 service:
   main:


### PR DESCRIPTION
- [X] Persist state periodically (and on shutdown), and recover when restarting `l1-devnet`.
- [x] Store persisted state on a persistent volume.

Fixes #39.