### PR TITLE
fix: l1-devnet dockerfile anvil version

### DIFF
--- a/charts/scroll-stack/charts/l1-devnet/values.yaml
+++ b/charts/scroll-stack/charts/l1-devnet/values.yaml
@@ -11,7 +11,7 @@ controller:
 image:
   repository: scrolltech/l1-devnet
   pullPolicy: Always
-  tag: v0.0.2
+  tag: v0.0.4
 
 command:
   ["/bin/bash","-c","anvil --host 0.0.0.0 --port 8545 --chain-id ${CHAIN_ID} --state /data/state.json --state-interval 60"]

--- a/custom-images/l1-devnet/Dockerfile
+++ b/custom-images/l1-devnet/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="/root/.foundry/bin:${PATH}"
 
 # Run foundryup to update Foundry
-RUN foundryup
+RUN foundryup -v nightly-7f0f5b4c1aa75dc4fd2eb15aca9757491d885902
 
 # Expose the port Anvil uses (default: 8545)
 EXPOSE 8545


### PR DESCRIPTION
Problem:
The l1-devnet we have now using a Anvil version not compatible to our go package.

Solution:
Use a specific version of Anvil to build the l1-devnet docker image.