### PR TITLE
feat: Expose re-generating config files in devnet

### DIFF
--- a/devnet/Makefile
+++ b/devnet/Makefile
@@ -2,7 +2,7 @@
 ARCH_ARM64 := $(shell if [ "$$(uname -m)" = "arm64" ] || [ "$$(uname -m)" = "aarch64" ]; then echo "-arm64"; else echo ""; fi)
 ARCH_OTHER := $(shell if [ "$$(uname -m)" != "arm64" ] && [ "$$(uname -m)" != "aarch64" ]; then echo "scroll-"; else echo ""; fi)
 L2_IMAGE_TAG := $(ARCH_OTHER)v5.5.17$(ARCH_ARM64)
-L1_RPC_HOST := l1-rpc.scrollsdk
+L1_RPC_HOST := l1-devnet.scrollsdk
 
 bootstrap:
 		echo "Pulling helm chart..."


### PR DESCRIPTION
- Adds another make command to allow running the config generation file separately from bootstrap (otherwise, running bootstrap again overwrites changes)
- Creates an alias for upgrade pointing to make install
- fix incorrect URL set from different work around hack

Note: still included workaround hack for changing the RPC ingress URL