### PR TITLE
fix: Upadate prepare-config-files.sh to support linux

### DIFF
--- a/devnet/prepare-config-files.sh
+++ b/devnet/prepare-config-files.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Give the current user the appropriate permissions
+sudo chown -R $(whoami):$(whoami) scroll-sdk
+sudo chmod -R u+rw scroll-sdk
+
 indent_file_and_add_first_line () {
   echo $1
   temp_file="tmp_file"


### PR DESCRIPTION
On linux, the files returned by `helm` don't have the appropriate permissions. This means that `make bootstrap` under the `devnet/` directory returns `Permission denied` unless it's run with `sudo`, which it shouldn't be used.

This PR adjusts the permissions recursively after the files are pulled. This allows linux users to launch their local devnet without the need of using `sudo`.

Tested on Ubuntu 24.04 LTS clean install.