### PR TITLE
fea(ci): add example charts sync validation

### DIFF
--- a/.github/scripts/validate_charts.py
+++ b/.github/scripts/validate_charts.py
@@ -4,28 +4,52 @@ import glob
 import os
 import re
 import sys
+from difflib import unified_diff
 from pathlib import Path
 
 import yaml
 
 
 def load_yaml_file(file_path):
+    if not os.path.exists(file_path):
+        print(f"Error: File not found: {file_path}")
+        return None, None
+
     try:
-        with open(file_path, "r") as f:
-            return yaml.safe_load(f)
+        with open(file_path, "r", encoding="utf-8") as f:
+            raw_content = f.read()
+            yaml_content = yaml.safe_load(raw_content)
+            return yaml_content, raw_content
     except Exception as e:
         print(f"Error loading {file_path}: {e}")
-        return None
+        return None, None
 
 
 def compare_yaml_files(file1, file2):
-    content1 = load_yaml_file(file1)
-    content2 = load_yaml_file(file2)
+    result1 = load_yaml_file(file1)
+    result2 = load_yaml_file(file2)
+
+    if result1[0] is None or result2[0] is None:
+        return False
+
+    content1, raw1 = result1
+    content2, raw2 = result2
 
     if content1 != content2:
-        print("❌ Files are not in sync:")
-        print(f"  - {file1}")
-        print(f"  - {file2}")
+        print("❌ Files are not in sync!")
+        print(f"Source file: {file1}")
+        print(f"Target file: {file2}")
+        print("-" * 80)
+
+        # Generate and print git-style diff
+        diff = unified_diff(
+            raw1.splitlines(keepends=True),
+            raw2.splitlines(keepends=True),
+            fromfile="Source",
+            tofile="Target",
+            lineterm="",
+        )
+        print("".join(list(diff)))
         return False
     return True
 
@@ -34,33 +58,20 @@ def validate_production_files():
     success = True
 
     # Check values files sync
-    chart_values = glob.glob("charts/**/values/production.yaml", recursive=True)
+    chart_values = glob.glob("charts/**/values/production*.yaml", recursive=True)
     for chart_value_file in chart_values:
         service_name = Path(chart_value_file).parts[-3]
+        production_file = Path(chart_value_file).parts[-1]  # e.g. "production-0.yaml"
 
-        # Find all corresponding example files
-        example_files = glob.glob(f"examples/values/{service_name}-production*.yaml")
+        # Construct the corresponding example file path
+        example_file = f"examples/values/{service_name}-{production_file}"
 
-        if not example_files:
-            # For services with single instance
-            example_file = f"examples/values/{service_name}-production.yaml"
-            if os.path.exists(example_file):
-                if not compare_yaml_files(chart_value_file, example_file):
-                    success = False
-            else:
-                print(f"❌ Missing example values file: {example_file}")
+        if os.path.exists(example_file):
+            if not compare_yaml_files(chart_value_file, example_file):
                 success = False
         else:
-            # For services with multiple instances (like l2-sequencer-0, l2-sequencer-1)
-            # Each instance should have its own example file
-            base_content = load_yaml_file(chart_value_file)
-            if not base_content:
-                success = False
-                continue
-
-            for example_file in example_files:
-                if not compare_yaml_files(chart_value_file, example_file):
-                    success = False
+            print(f"❌ Missing example values file: {example_file}")
+            success = False
 
     return success
 
@@ -71,11 +82,13 @@ def validate_example_makefile():
         return True
 
     with open(makefile_path, "r") as f:
-        makefile_content = f.read()
+        # Replace line continuations (\newline) with spaces
+        makefile_content = re.sub(r"\\\n\s*", " ", f.read())
 
-    # Extract version patterns like '--version=X.X.X'
+    # Extract version patterns from helm upgrade commands
     version_patterns = re.findall(
-        r"helm upgrade -i ([^\s]+) .+?--version=(\d+\.\d+\.\d+)", makefile_content
+        r"helm upgrade -i ([a-zA-Z0-9-]+)\s+oci://[^\s]+\s+.*?--version=(\d+\.\d+\.\d+)",
+        makefile_content,
     )
 
     success = True
@@ -91,10 +104,10 @@ def validate_example_makefile():
             continue
 
         chart_data = load_yaml_file(chart_file)
-        if not chart_data:
+        if not chart_data[0]:
             continue
 
-        chart_version = chart_data.get("version")
+        chart_version = chart_data[0].get("version")
         if version != chart_version:
             print(f"❌ Version mismatch in Makefile.example for {base_service}")
             print(f"  Makefile version: {version}")
@@ -108,8 +121,8 @@ def main():
     success = True
 
     # Check production files sync
-    # if not validate_production_files():
-    #     success = False
+    if not validate_production_files():
+        success = False
 
     # Check example Makefile versions
     if not validate_example_makefile():

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -97,7 +97,7 @@ install:
 
 install-l1-devnet:
 	helm upgrade -i l1-devnet oci://ghcr.io/scroll-tech/scroll-sdk/helm/l1-devnet -n $(NAMESPACE) \
-		--version=0.0.2 \
+		--version=0.0.3 \
 		--values values/l1-devnet-production.yaml
 
 delete:


### PR DESCRIPTION
# Add Chart Sync Validation

1. Added a GitHub Action that triggers on:

- Changes to chart production values files
- Changes to example production values files
- Changes to Chart.yaml files
- Changes to examples/Makefile.example

2. Added a validation script that performs two main checks:

- Ensures production values files in `charts/*/values/` have matching copies in `examples/values/`
- Validates that versions in `examples/Makefile.example` match their corresponding chart versions

The script provides detailed diff output when files are out of sync, making it easy to spot differences.

## Example Output
When files are out of sync:
```
❌ Files are not in sync!
Source file: charts/service/values/production.yaml
Target file: examples/values/service-production.yaml
--------------------------------------------------------------------------------
--- Source
+++ Target
@@ -1,5 +1,6 @@
 config:
-  key: old_value
+  key: new_value
+  new_key: value
```

When versions don't match:
```
❌ Version mismatch in Makefile.example for service
  Makefile version: 0.0.1
  Chart version: 0.0.2
```

## Purpose
This validation helps ensure that:
1. Example files stay up to date with their source files
2. Chart versions in the example Makefile match the actual chart versions
3. Contributors don't accidentally forget to update example files