### PR TITLE
fix: macos whoami issue

### DIFF
--- a/devnet/prepare-config-files.sh
+++ b/devnet/prepare-config-files.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# Give the current user the appropriate permissions
-sudo chown -R $(whoami):$(whoami) scroll-sdk
-sudo chmod -R u+rw scroll-sdk
+# Check if running on Linux (skip permission changes on macOS)
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    # On Linux systems, set permissions
+    sudo chown -R $(whoami):$(whoami) scroll-sdk
+    sudo chmod -R u+rw scroll-sdk
+fi
 
 indent_file_and_add_first_line () {
   echo $1


### PR DESCRIPTION
Because this seems to be a permissions issue on linux, I'm removing it from macOS flow.

Sudo access isn't great, and macOS doesn't use the same user:group convention as Ubuntu, so it throws an error.